### PR TITLE
Optimize Spark History Server for loading large number of applications on startup

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileReaders.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileReaders.scala
@@ -193,7 +193,7 @@ class SingleFileEventLogFileReader(
     addFileAsZipEntry(zipStream, rootPath, rootPath.getName)
   }
 
-  override def listEventLogFiles: Seq[FileStatus] = Seq(this.status)
+  override def listEventLogFiles: Seq[FileStatus] = Seq(status)
 
   override def compressionCodec: Option[String] = EventLogFileWriter.codecName(rootPath)
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileReaders.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileReaders.scala
@@ -193,9 +193,7 @@ class SingleFileEventLogFileReader(
     addFileAsZipEntry(zipStream, rootPath, rootPath.getName)
   }
 
-  override def listEventLogFiles: Seq[FileStatus] = {
-    Seq(this.status)
-  }
+  override def listEventLogFiles: Seq[FileStatus] = Seq(this.status)
 
   override def compressionCodec: Option[String] = EventLogFileWriter.codecName(rootPath)
 

--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileReaders.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileReaders.scala
@@ -106,7 +106,7 @@ object EventLogFileReader {
       lastIndex: Option[Long]): EventLogFileReader = {
     lastIndex match {
       case Some(_) => new RollingEventLogFilesFileReader(fs, path)
-      case None => new SingleFileEventLogFileReader(fs, path)
+      case None => new SingleFileEventLogFileReader(fs, path, 0)
     }
   }
 
@@ -116,7 +116,7 @@ object EventLogFileReader {
 
   def apply(fs: FileSystem, status: FileStatus): Option[EventLogFileReader] = {
     if (isSingleEventLog(status)) {
-      Some(new SingleFileEventLogFileReader(fs, status.getPath))
+      Some(new SingleFileEventLogFileReader(fs, status.getPath, status.getLen))
     } else if (isRollingEventLogs(status)) {
       Some(new RollingEventLogFilesFileReader(fs, status.getPath))
     } else {
@@ -166,12 +166,12 @@ object EventLogFileReader {
  */
 class SingleFileEventLogFileReader(
     fs: FileSystem,
-    path: Path) extends EventLogFileReader(fs, path) {
+    path: Path, len: Long) extends EventLogFileReader(fs, path) {
   private lazy val status = fileSystem.getFileStatus(rootPath)
 
   override def lastIndex: Option[Long] = None
 
-  override def fileSizeForLastIndex: Long = status.getLen
+  override def fileSizeForLastIndex: Long = len
 
   override def completed: Boolean = !rootPath.getName.stripSuffix(EventLogFileWriter.COMPACTED)
     .endsWith(EventLogFileWriter.IN_PROGRESS)

--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileReaders.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileReaders.scala
@@ -106,7 +106,7 @@ object EventLogFileReader {
       lastIndex: Option[Long]): EventLogFileReader = {
     lastIndex match {
       case Some(_) => new RollingEventLogFilesFileReader(fs, path)
-      case None => new SingleFileEventLogFileReader(fs, path, 0)
+      case None => new SingleFileEventLogFileReader(fs, path, new FileStatus())
     }
   }
 
@@ -116,7 +116,7 @@ object EventLogFileReader {
 
   def apply(fs: FileSystem, status: FileStatus): Option[EventLogFileReader] = {
     if (isSingleEventLog(status)) {
-      Some(new SingleFileEventLogFileReader(fs, status.getPath, status.getLen))
+      Some(new SingleFileEventLogFileReader(fs, status.getPath, status))
     } else if (isRollingEventLogs(status)) {
       Some(new RollingEventLogFilesFileReader(fs, status.getPath))
     } else {
@@ -166,12 +166,12 @@ object EventLogFileReader {
  */
 class SingleFileEventLogFileReader(
     fs: FileSystem,
-    path: Path, len: Long) extends EventLogFileReader(fs, path) {
-  private lazy val status = fileSystem.getFileStatus(rootPath)
-
+    path: Path, status:FileStatus) extends EventLogFileReader(fs, path) {
+  //private lazy val status = fileSystem.getFileStatus(rootPath)
+  
   override def lastIndex: Option[Long] = None
 
-  override def fileSizeForLastIndex: Long = len
+  override def fileSizeForLastIndex: Long = status.getLen
 
   override def completed: Boolean = !rootPath.getName.stripSuffix(EventLogFileWriter.COMPACTED)
     .endsWith(EventLogFileWriter.IN_PROGRESS)

--- a/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileReaders.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/EventLogFileReaders.scala
@@ -200,7 +200,6 @@ class SingleFileEventLogFileReader(
   override def compressionCodec: Option[String] = EventLogFileWriter.codecName(rootPath)
 
   override def totalSize: Long = fileSizeForLastIndex
-
 }
 
 /**

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -466,7 +466,6 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         .flatMap { entry => EventLogFileReader(fs, entry) }
         .filter { reader =>
           try {
-            // logDebug("working on application located at: " + reader.rootPath.toString())
             val info = listing.read(classOf[LogInfo], reader.rootPath.toString())            
 
             if (info.appId.isDefined) {
@@ -1063,9 +1062,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     } replayBus.addListener(listener)
 
     try {
-      //logInfo("**** class of reader: "+reader.getClass().toString())
       val eventLogFiles = reader.listEventLogFiles
-      //logInfo("**** num files in the reader: "+eventLogFiles.length+"; files: "+eventLogFiles)
       logInfo(s"Parsing ${reader.rootPath} to re-build UI...")
       parseAppEventLogs(eventLogFiles, replayBus, !reader.completed)
       trackingStore.close(false)
@@ -1088,7 +1085,6 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     var continueReplay = true
     logFiles.foreach { file =>
       if (continueReplay) {
-        logInfo("**** file class: "+file.getClass().toString()+"; file path: "+file.getPath+"; file: "+file.toString())
         Utils.tryWithResource(EventLogFileReader.openEventLog(file.getPath, fs)) { in =>
           continueReplay = replayBus.replay(in, file.getPath.toString,
             maybeTruncated = maybeTruncated, eventsFilter = eventsFilter)
@@ -1215,7 +1211,6 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     while (store == null) {
       try {
         val s = new InMemoryStore()
-        //logInfo("**** logDir: "+logDir+"; logPath: "+attempt.logPath)
         val reader = EventLogFileReader(fs, new Path(logDir, attempt.logPath),
           attempt.lastIndex)
         rebuildAppStore(s, reader, attempt.info.lastUpdated.getTime())

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -466,7 +466,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         .flatMap { entry => EventLogFileReader(fs, entry) }
         .filter { reader =>
           try {
-            //logDebug("working on application located at: " + reader.rootPath.toString())
+            logDebug("working on application located at: " + reader.rootPath.toString())
             val info = listing.read(classOf[LogInfo], reader.rootPath.toString())            
 
             if (info.appId.isDefined) {

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -466,6 +466,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         .filter { reader =>
           try {
             val info = listing.read(classOf[LogInfo], reader.rootPath.toString())
+            logDebug("working on application located at: " + entry.getPath().toString())
 
             if (info.appId.isDefined) {
               // If the SHS view has a valid application, update the time the file was last seen so

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -457,6 +457,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
   private[history] def checkForLogs(): Unit = {
     try {
       val newLastScanTime = clock.getTimeMillis()
+      logDebug("Checking change")
       logDebug(s"Scanning $logDir with lastScanTime==$lastScanTime")
 
       val updated = Option(fs.listStatus(new Path(logDir))).map(_.toSeq).getOrElse(Nil)

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -539,7 +539,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         }
 
       if (updated.nonEmpty) {
-        logDebug(s"New/updated attempts found: ${updated.size} ${updated.map(_.rootPath)}")
+//        logDebug(s"New/updated attempts found: ${updated.size} ${updated.map(_.rootPath)}")
       }
 
       updated.foreach { entry =>
@@ -1063,7 +1063,9 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     } replayBus.addListener(listener)
 
     try {
+      //logInfo("**** class of reader: "+reader.getClass().toString())
       val eventLogFiles = reader.listEventLogFiles
+      //logInfo("**** num files in the reader: "+eventLogFiles.length+"; files: "+eventLogFiles)
       logInfo(s"Parsing ${reader.rootPath} to re-build UI...")
       parseAppEventLogs(eventLogFiles, replayBus, !reader.completed)
       trackingStore.close(false)
@@ -1086,6 +1088,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     var continueReplay = true
     logFiles.foreach { file =>
       if (continueReplay) {
+        logInfo("**** file class: "+file.getClass().toString()+"; file path: "+file.getPath+"; file: "+file.toString())
         Utils.tryWithResource(EventLogFileReader.openEventLog(file.getPath, fs)) { in =>
           continueReplay = replayBus.replay(in, file.getPath.toString,
             maybeTruncated = maybeTruncated, eventsFilter = eventsFilter)
@@ -1212,6 +1215,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
     while (store == null) {
       try {
         val s = new InMemoryStore()
+        //logInfo("**** logDir: "+logDir+"; logPath: "+attempt.logPath)
         val reader = EventLogFileReader(fs, new Path(logDir, attempt.logPath),
           attempt.lastIndex)
         rebuildAppStore(s, reader, attempt.info.lastUpdated.getTime())

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -538,7 +538,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         }
 
       if (updated.nonEmpty) {
-//        logDebug(s"New/updated attempts found: ${updated.size} ${updated.map(_.rootPath)}")
+        logDebug(s"New/updated attempts found: ${updated.size} ${updated.map(_.rootPath)}")
       }
 
       updated.foreach { entry =>

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -466,7 +466,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         .filter { reader =>
           try {
             val info = listing.read(classOf[LogInfo], reader.rootPath.toString())
-            logDebug("working on application located at: " + entry.getPath().toString())
+            logDebug("working on application located at: " + reader.rootPath.toString())
 
             if (info.appId.isDefined) {
               // If the SHS view has a valid application, update the time the file was last seen so

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -457,17 +457,17 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
   private[history] def checkForLogs(): Unit = {
     try {
       val newLastScanTime = clock.getTimeMillis()
-      logDebug("Checking change")
+      logDebug("Checking change 2")
       logDebug(s"Scanning $logDir with lastScanTime==$lastScanTime")
 
       val updated = Option(fs.listStatus(new Path(logDir))).map(_.toSeq).getOrElse(Nil)
-        .filter { entry => !isBlacklisted(entry.getPath) }
+        .filter { entry => !entry.isDirectory() && !entry.getPath().getName().startsWith(".") && !isBlacklisted(entry.getPath) }
         .filter { entry => !isProcessing(entry.getPath) }
         .flatMap { entry => EventLogFileReader(fs, entry) }
         .filter { reader =>
           try {
-            val info = listing.read(classOf[LogInfo], reader.rootPath.toString())
-            logDebug("working on application located at: " + reader.rootPath.toString())
+            //logDebug("working on application located at: " + reader.rootPath.toString())
+            val info = listing.read(classOf[LogInfo], reader.rootPath.toString())            
 
             if (info.appId.isDefined) {
               // If the SHS view has a valid application, update the time the file was last seen so

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -457,16 +457,15 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
   private[history] def checkForLogs(): Unit = {
     try {
       val newLastScanTime = clock.getTimeMillis()
-      logDebug("Checking change 2")
       logDebug(s"Scanning $logDir with lastScanTime==$lastScanTime")
 
       val updated = Option(fs.listStatus(new Path(logDir))).map(_.toSeq).getOrElse(Nil)
-        .filter { entry => !entry.isDirectory() && !entry.getPath().getName().startsWith(".") && !isBlacklisted(entry.getPath) }
+        .filter { entry => !isBlacklisted(entry.getPath) }
         .filter { entry => !isProcessing(entry.getPath) }
         .flatMap { entry => EventLogFileReader(fs, entry) }
         .filter { reader =>
           try {
-            val info = listing.read(classOf[LogInfo], reader.rootPath.toString())            
+            val info = listing.read(classOf[LogInfo], reader.rootPath.toString())
 
             if (info.appId.isDefined) {
               // If the SHS view has a valid application, update the time the file was last seen so

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -466,7 +466,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         .flatMap { entry => EventLogFileReader(fs, entry) }
         .filter { reader =>
           try {
-            logDebug("working on application located at: " + reader.rootPath.toString())
+            // logDebug("working on application located at: " + reader.rootPath.toString())
             val info = listing.read(classOf[LogInfo], reader.rootPath.toString())            
 
             if (info.appId.isDefined) {


### PR DESCRIPTION
`EventLogFileReader` object is created in multiple forms. While loading initially, it is given `FileStatus` which is being ignored and recomputing the `FileStatus`. This recomputation turned out to be very expensive when we were attempting to load 260k+ applications on startup.

Modified the code to use `FileStatus` if it is provided directly. If not, then compute it from the given path.