### PR TITLE
Log first successful container request

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/LyftUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/LyftUtils.scala
@@ -18,8 +18,14 @@
 package org.apache.spark.util
 
 private[spark] object LyftUtils {
-  def callObjectMethodNoArguments(objectName: String, method: String): Unit = {
+  def callObjectMethodNoArguments(objectName: String, method: String): Boolean = {
+    var ok = true
+    try {
       val m = Utils.classForName(objectName).getField("MODULE$").get(null)
       Utils.classForName(objectName).getDeclaredMethod(method).invoke(m)
+    } catch {
+      case e: Throwable => ok = false
+    }
+    ok
   }
 }

--- a/core/src/main/scala/org/apache/spark/util/LyftUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/LyftUtils.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+private[spark] object LyftUtils {
+  def callObjectMethodNoArguments(objectName: String, method: String): Unit = {
+      val m = Utils.classForName(objectName).getField("MODULE$").get(null)
+      Utils.classForName(objectName).getDeclaredMethod(method).invoke(m)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/util/LyftUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/LyftUtilsSuite.scala
@@ -30,7 +30,7 @@ object TestObjectLyftUtils {
 class LyftUtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
 
   test("callObjectMethodNoArguments") {
-    // Test -1
+    // Test calling the method using reflection 1
     LyftUtils.callObjectMethodNoArguments("org.apache.spark.util.TestObjectLyftUtils$", "setVal")
     assert(TestObjectLyftUtils.testVar === 1)
   }

--- a/core/src/test/scala/org/apache/spark/util/LyftUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/LyftUtilsSuite.scala
@@ -31,7 +31,10 @@ class LyftUtilsSuite extends SparkFunSuite with ResetSystemProperties with Loggi
 
   test("callObjectMethodNoArguments") {
     // Test calling the method using reflection 1
-    LyftUtils.callObjectMethodNoArguments("org.apache.spark.util.TestObjectLyftUtils$", "setVal")
+    val v = LyftUtils.callObjectMethodNoArguments("org.apache.spark.util.TestObjectLyftUtils$", "setVal")
+    assert(v === true)
     assert(TestObjectLyftUtils.testVar === 1)
+    assert(false ==
+      LyftUtils.callObjectMethodNoArguments("org.apache.spark.util.TestObjectLyftUtils$", "setVal1"))
   }
 }

--- a/core/src/test/scala/org/apache/spark/util/LyftUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/LyftUtilsSuite.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+import org.apache.spark.{SparkException, SparkFunSuite}
+import org.apache.spark.internal.Logging
+
+object TestObjectLyftUtils {
+  var testVar = 0L
+  def setVal() = {
+    testVar = 1L
+  }
+}
+
+class LyftUtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
+
+  test("callObjectMethodNoArguments") {
+    // Test -1
+    LyftUtils.callObjectMethodNoArguments("org.apache.spark.util.TestObjectLyftUtils$", "setVal")
+    assert(TestObjectLyftUtils.testVar === 1)
+  }
+}

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -222,13 +222,11 @@ private[spark] class ExecutorPodsAllocator(
         kubernetesClient.pods().create(podWithAttachedContainer)
         newlyCreatedExecutors(newExecutorId) = clock.getTimeMillis()
         logDebug(s"Requested executor with id $newExecutorId from Kubernetes.")
-        try {
-          val m = Class.forName("com.lyft.data.spark.AppMetrics$").getField("MODULE$").get(null)
-          Class.forName("com.lyft.data.spark.AppMetrics$")
-            .getDeclaredMethod("setFirstExecutorAllocationTime").invoke(m)
-        } catch {
-          case e: Throwable =>
-        }
+
+
+        org.apache.spark.util.LyftUtils.callObjectMethodNoArguments(
+          "com.lyft.data.spark.AppMetrics$",
+          "setFirstExecutorAllocationTime")
       }
     }
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -222,6 +222,13 @@ private[spark] class ExecutorPodsAllocator(
         kubernetesClient.pods().create(podWithAttachedContainer)
         newlyCreatedExecutors(newExecutorId) = clock.getTimeMillis()
         logDebug(s"Requested executor with id $newExecutorId from Kubernetes.")
+        try {
+          val m = Class.forName("com.lyft.data.spark.AppMetrics$").getField("MODULE$").get(null)
+          Class.forName("com.lyft.data.spark.AppMetrics$")
+            .getDeclaredMethod("setFirstExecutorAllocationTime").invoke(m)
+        } catch {
+          case e: Throwable =>
+        }
       }
     }
 


### PR DESCRIPTION
Call internal lyft API using reflection when the executor was successfully requested from K8s