### PR TITLE
Trunc function does not contain the Q string (for quarter)

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -2687,7 +2687,7 @@ object DatePart {
       errorHandleFunc: => Nothing): Expression = extractField.toUpperCase(Locale.ROOT) match {
     case "YEAR" | "Y" | "YEARS" | "YR" | "YRS" => Year(source)
     case "YEAROFWEEK" => YearOfWeek(source)
-    case "QUARTER" | "QTR" => Quarter(source)
+    case "QUARTER" | "QTR" | "Q" => Quarter(source)
     case "MONTH" | "MON" | "MONS" | "MONTHS" => Month(source)
     case "WEEK" | "W" | "WEEKS" => WeekOfYear(source)
     case "DAY" | "D" | "DAYS" => DayOfMonth(source)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -139,11 +139,6 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
         s"as table property keys may not start with '$SPARK_SQL_PREFIX': " +
         invalidKeys.mkString("[", ", ", "]"))
     }
-    // External users are not allowed to set/switch the table type. In Hive metastore, the table
-    // type can be switched by changing the value of a case-sensitive table property `EXTERNAL`.
-    if (table.properties.contains("EXTERNAL")) {
-      throw new AnalysisException("Cannot set or change the preserved property key: 'EXTERNAL'")
-    }
   }
 
   /**

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala
@@ -139,6 +139,7 @@ private[spark] class HiveExternalCatalog(conf: SparkConf, hadoopConf: Configurat
         s"as table property keys may not start with '$SPARK_SQL_PREFIX': " +
         invalidKeys.mkString("[", ", ", "]"))
     }
+    // To keep the parity with Hive, the check for external table properties has been removed.
   }
 
   /**

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -821,6 +821,36 @@ class HiveDDLSuite
       s"$tableName is a table. '$cmdName' expects a view. Please use ALTER TABLE instead.")
   }
 
+  ignore("create table - SET TBLPROPERTIES EXTERNAL to TRUE") {
+    val tabName = "tab1"
+    withTable(tabName) {
+      assertAnalysisError(
+        s"CREATE TABLE $tabName (height INT, length INT) TBLPROPERTIES('EXTERNAL'='TRUE')",
+        "Cannot set or change the preserved property key: 'EXTERNAL'")
+    }
+  }
+
+  ignore("alter table - SET TBLPROPERTIES EXTERNAL to TRUE") {
+    val tabName = "tab1"
+    withTable(tabName) {
+      val catalog = spark.sessionState.catalog
+      sql(s"CREATE TABLE $tabName (height INT, length INT)")
+      assert(
+        catalog.getTableMetadata(TableIdentifier(tabName)).tableType == CatalogTableType.MANAGED)
+      assertAnalysisError(
+        s"ALTER TABLE $tabName SET TBLPROPERTIES ('EXTERNAL' = 'TRUE')",
+        "Cannot set or change the preserved property key: 'EXTERNAL'")
+      // The table type is not changed to external
+      assert(
+        catalog.getTableMetadata(TableIdentifier(tabName)).tableType == CatalogTableType.MANAGED)
+      // The table property is case sensitive. Thus, external is allowed
+      sql(s"ALTER TABLE $tabName SET TBLPROPERTIES ('external' = 'TRUE')")
+      // The table type is not changed to external
+      assert(
+        catalog.getTableMetadata(TableIdentifier(tabName)).tableType == CatalogTableType.MANAGED)
+    }
+  }
+
   test("alter views and alter table - misuse") {
     val tabName = "tab1"
     withTable(tabName) {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -821,36 +821,6 @@ class HiveDDLSuite
       s"$tableName is a table. '$cmdName' expects a view. Please use ALTER TABLE instead.")
   }
 
-  test("create table - SET TBLPROPERTIES EXTERNAL to TRUE") {
-    val tabName = "tab1"
-    withTable(tabName) {
-      assertAnalysisError(
-        s"CREATE TABLE $tabName (height INT, length INT) TBLPROPERTIES('EXTERNAL'='TRUE')",
-        "Cannot set or change the preserved property key: 'EXTERNAL'")
-    }
-  }
-
-  test("alter table - SET TBLPROPERTIES EXTERNAL to TRUE") {
-    val tabName = "tab1"
-    withTable(tabName) {
-      val catalog = spark.sessionState.catalog
-      sql(s"CREATE TABLE $tabName (height INT, length INT)")
-      assert(
-        catalog.getTableMetadata(TableIdentifier(tabName)).tableType == CatalogTableType.MANAGED)
-      assertAnalysisError(
-        s"ALTER TABLE $tabName SET TBLPROPERTIES ('EXTERNAL' = 'TRUE')",
-        "Cannot set or change the preserved property key: 'EXTERNAL'")
-      // The table type is not changed to external
-      assert(
-        catalog.getTableMetadata(TableIdentifier(tabName)).tableType == CatalogTableType.MANAGED)
-      // The table property is case sensitive. Thus, external is allowed
-      sql(s"ALTER TABLE $tabName SET TBLPROPERTIES ('external' = 'TRUE')")
-      // The table type is not changed to external
-      assert(
-        catalog.getTableMetadata(TableIdentifier(tabName)).tableType == CatalogTableType.MANAGED)
-    }
-  }
-
   test("alter views and alter table - misuse") {
     val tabName = "tab1"
     withTable(tabName) {


### PR DESCRIPTION
- Enable Trunc to handle Q (QUARTER) that Hive does (more context: https://lyft.slack.com/archives/C01N6FA0NSK/p1639004359041500)
- Allow Spark to modify the table type (Internal <-> External) ( Hive partity issue).