### PR TITLE
Remove unnecessary logging statements

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/Logging.scala
+++ b/core/src/main/scala/org/apache/spark/internal/Logging.scala
@@ -161,11 +161,6 @@ trait Logging {
         }
         // Update the consoleAppender threshold to replLevel
         if (replLevel != rootLogger.getLevel()) {
-          if (!silent) {
-            System.err.printf("Setting default log level to \"%s\".\n", replLevel)
-            System.err.println("To adjust logging level use sc.setLogLevel(newLevel). " +
-              "For SparkR, use setLogLevel(newLevel).")
-          }
           Logging.sparkShellThresholdLevel = replLevel
           rootLogger.getAppenders().asScala.foreach {
             case (_, ca: ConsoleAppender) =>


### PR DESCRIPTION
Remove repl logging statements which for some reason get logged even outside of a repl.