### PR TITLE
Prevent YARN filter from being added to the Spark UI

### DIFF
--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -316,7 +316,7 @@ private[spark] class ApplicationMaster(
       registerAM(Utils.localHostName, -1, sparkConf,
         sparkConf.getOption("spark.driver.appUIAddress"), appAttemptId)
       val encodedAppId = URLEncoder.encode(appAttemptId.getApplicationId.toString, "UTF-8")
-      addAmIpFilter(Some(driverRef), s"/proxy/$encodedAppId")
+//      addAmIpFilter(Some(driverRef), s"/proxy/$encodedAppId")
       createAllocator(driverRef, sparkConf, clientRpcEnv, appAttemptId, cachedResourcesConf)
       reporterThread.join()
     } catch {
@@ -499,7 +499,7 @@ private[spark] class ApplicationMaster(
   }
 
   private def runDriver(): Unit = {
-    addAmIpFilter(None, System.getenv(ApplicationConstants.APPLICATION_WEB_PROXY_BASE_ENV))
+//    addAmIpFilter(None, System.getenv(ApplicationConstants.APPLICATION_WEB_PROXY_BASE_ENV))
     userClassThread = startUserApplication()
 
     // This a bit hacky, but we need to wait until the spark.driver.port property has
@@ -556,8 +556,8 @@ private[spark] class ApplicationMaster(
     val driverRef = rpcEnv.setupEndpointRef(
       RpcAddress(driverHost, driverPort),
       YarnSchedulerBackend.ENDPOINT_NAME)
-    addAmIpFilter(Some(driverRef),
-      System.getenv(ApplicationConstants.APPLICATION_WEB_PROXY_BASE_ENV))
+//    addAmIpFilter(Some(driverRef),
+//      System.getenv(ApplicationConstants.APPLICATION_WEB_PROXY_BASE_ENV))
     createAllocator(driverRef, sparkConf, rpcEnv, appAttemptId, distCacheConf)
 
     // In client mode the actor will stop the reporter thread.


### PR DESCRIPTION
This PR prevents the Spark UI to redirect the request to the RM web proxy, but instead to serve it directly in YARN mode.
This improves the availability of the Spark UI in YARN mode especially in cross cluster scenarios or when using unmanaged AM.