### PR TITLE
[BATCHCMP-379] Port over Lyft Spark v3.3 custom patches

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -18,7 +18,7 @@
 package org.apache.spark
 
 import java.io.File
-import java.net.Socket
+import java.net.{InetAddress, Socket}
 import java.util.Locale
 
 import scala.collection.JavaConverters._
@@ -207,11 +207,15 @@ object SparkEnv extends Logging {
       numCores: Int,
       ioEncryptionKey: Option[Array[Byte]],
       isLocal: Boolean): SparkEnv = {
+    var hostnameFinal = hostname
+    if (conf.getBoolean("spark.lyft.resolve", false)) {
+      hostnameFinal = InetAddress.getByName(hostname).getHostAddress
+    }
     val env = create(
       conf,
       executorId,
       bindAddress,
-      hostname,
+      hostnameFinal,
       None,
       isLocal,
       numCores,

--- a/core/src/main/scala/org/apache/spark/util/LyftUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/LyftUtils.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+private[spark] object LyftUtils {
+  def callObjectMethodNoArguments(objectName: String, method: String): Boolean = {
+    var ok = true
+    try {
+      val m = Utils.classForName(objectName).getField("MODULE$").get(null)
+      Utils.classForName(objectName).getDeclaredMethod(method).invoke(m)
+    } catch {
+      case e: Throwable => ok = false
+    }
+    ok
+  }
+}

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2220,8 +2220,15 @@ private[spark] object Utils
    * privileged ports.
    */
   def userPort(base: Int, offset: Int): Int = {
-    (base + offset - 1024) % (65536 - 1024) + 1024
+      (base + offset - 1024) % (65536 - 1024) + 1024
   }
+
+  def randPort(base: Int, offset: Int, maxRand: Int): Int = {
+      val rand = new scala.util.Random
+      val r = rand.nextInt(maxRand)
+      (base + offset + r) % 65535
+  }
+
 
   /**
    * Attempt to start a service on the given port, or fail after a number of attempts.
@@ -2249,6 +2256,10 @@ private[spark] object Utils
       // Do not increment port if startPort is 0, which is treated as a special port
       val tryPort = if (startPort == 0) {
         startPort
+      } else if (offset > 0 && conf.getInt("spark.lyft.maxrand", 0) > 0)
+      {
+        logInfo(s"Using randPort")
+        randPort(startPort, offset, conf.getInt("spark.lyft.maxrand", 0))
       } else {
         userPort(startPort, offset)
       }

--- a/core/src/test/scala/org/apache/spark/util/LyftUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/LyftUtilsSuite.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+import org.apache.spark.{SparkException, SparkFunSuite}
+import org.apache.spark.internal.Logging
+
+object TestObjectLyftUtils {
+  var testVar = 0L
+  def setVal() = {
+    testVar = 1L
+  }
+}
+
+class LyftUtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
+
+  test("callObjectMethodNoArguments") {
+    // Test calling the method using reflection 1
+    val v = LyftUtils.callObjectMethodNoArguments("org.apache.spark.util.TestObjectLyftUtils$", "setVal")
+    assert(v === true)
+    assert(TestObjectLyftUtils.testVar === 1)
+    assert(false ==
+      LyftUtils.callObjectMethodNoArguments("org.apache.spark.util.TestObjectLyftUtils$", "setVal1"))
+  }
+}

--- a/core/src/test/scala/org/apache/spark/util/LyftUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/LyftUtilsSuite.scala
@@ -17,12 +17,12 @@
 
 package org.apache.spark.util
 
-import org.apache.spark.{SparkException, SparkFunSuite}
+import org.apache.spark.{SparkFunSuite}
 import org.apache.spark.internal.Logging
 
 object TestObjectLyftUtils {
   var testVar = 0L
-  def setVal() = {
+  def setVal(): Unit = {
     testVar = 1L
   }
 }
@@ -30,11 +30,12 @@ object TestObjectLyftUtils {
 class LyftUtilsSuite extends SparkFunSuite with ResetSystemProperties with Logging {
 
   test("callObjectMethodNoArguments") {
-    // Test calling the method using reflection 1
-    val v = LyftUtils.callObjectMethodNoArguments("org.apache.spark.util.TestObjectLyftUtils$", "setVal")
+    // Test calling the method using reflection
+    val v = LyftUtils.callObjectMethodNoArguments(
+      "org.apache.spark.util.TestObjectLyftUtils$", "setVal")
     assert(v === true)
     assert(TestObjectLyftUtils.testVar === 1)
-    assert(false ==
-      LyftUtils.callObjectMethodNoArguments("org.apache.spark.util.TestObjectLyftUtils$", "setVal1"))
+    assert(false == LyftUtils.callObjectMethodNoArguments(
+      "org.apache.spark.util.TestObjectLyftUtils$", "setVal1"))
   }
 }

--- a/hadoop-cloud/src/main/scala/org/apache/spark/internal/io/cloud/PathOutputCommitProtocol.scala
+++ b/hadoop-cloud/src/main/scala/org/apache/spark/internal/io/cloud/PathOutputCommitProtocol.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.internal.io.cloud
 
-import java.io.IOException
-
 import org.apache.hadoop.fs.{Path, StreamCapabilities}
 import org.apache.hadoop.mapreduce.TaskAttemptContext
 import org.apache.hadoop.mapreduce.lib.output.{FileOutputCommitter, PathOutputCommitter, PathOutputCommitterFactory}
@@ -60,6 +58,15 @@ class PathOutputCommitProtocol(
     dynamicPartitionOverwrite: Boolean = false)
   extends HadoopMapReduceCommitProtocol(jobId, dest, dynamicPartitionOverwrite)
     with Serializable {
+
+  if (dynamicPartitionOverwrite) {
+    // until there's explicit extensions to the PathOutputCommitProtocols
+    // to support the spark mechanism, it's left to the individual committer
+    // choice to handle partitioning.
+    // throw new IOException(PathOutputCommitProtocol.UNSUPPORTED)
+    // The above exception is disabled with automatic value of
+    // fs.s3a.committer.staging.conflict-mode in HadoopMapReduceCommitProtocol.
+  }
 
   /** The committer created. */
   @transient private var committer: PathOutputCommitter = _

--- a/hadoop-cloud/src/main/scala/org/apache/spark/internal/io/cloud/PathOutputCommitProtocol.scala
+++ b/hadoop-cloud/src/main/scala/org/apache/spark/internal/io/cloud/PathOutputCommitProtocol.scala
@@ -130,7 +130,9 @@ class PathOutputCommitProtocol(
           logDebug(
             s"Committer $committer has declared compatibility with dynamic partition overwrite")
         } else {
-          throw new IOException(PathOutputCommitProtocol.UNSUPPORTED + ": " + committer)
+          // throw new IOException(PathOutputCommitProtocol.UNSUPPORTED + ": " + committer)
+          // The above exception is disabled with automatic value of
+          // fs.s3a.committer.staging.conflict-mode in HadoopMapReduceCommitProtocol.
         }
       }
     }

--- a/hadoop-cloud/src/test/scala/org/apache/spark/internal/io/cloud/CommitterBindingSuite.scala
+++ b/hadoop-cloud/src/test/scala/org/apache/spark/internal/io/cloud/CommitterBindingSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.internal.io.cloud
 
-import java.io.{File, FileInputStream, FileOutputStream, IOException, ObjectInputStream, ObjectOutputStream}
+import java.io.{File, FileInputStream, FileOutputStream, ObjectInputStream, ObjectOutputStream}
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{Path, StreamCapabilities}
@@ -148,6 +148,9 @@ class CommitterBindingSuite extends SparkFunSuite {
    * Bind a job to a committer which doesn't support dynamic partitioning.
    * Job setup must fail, and calling `newTaskTempFileAbsPath()` must
    * raise `UnsupportedOperationException`.
+   * With custom patch https://github.com/lyft/spark/pull/34:
+   *  Job setup should now succeed (due to custom patch), but calling
+   *  `newTaskTempFileAbsPath()` must still raise `UnsupportedOperationException`.
    */
   test("reject dynamic partitioning if not supported") {
     val path = new Path("http://example/data")
@@ -162,14 +165,13 @@ class CommitterBindingSuite extends SparkFunSuite {
       jobId,
       path.toUri.toString,
       true)
-    val ioe = intercept[IOException] {
-      committer.setupJob(tContext)
-    }
-    if (!ioe.getMessage.contains(PathOutputCommitProtocol.UNSUPPORTED)) {
-      throw ioe
-    }
 
-    // calls to newTaskTempFileAbsPath() will be rejected
+    // Job setup should now succeed due to the custom patch that disabled
+    // the IOException throwing for unsupported dynamic partitioning
+    committer.setupJob(tContext)
+    committer.setupTask(tContext)
+
+    // calls to newTaskTempFileAbsPath() will still be rejected
     intercept[UnsupportedOperationException] {
       verifyAbsTempFileWorks(tContext, committer)
     }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -466,8 +466,12 @@ class ExecutorPodsAllocator(
         .build()
       val resources = replacePVCsIfNeeded(
         podWithAttachedContainer, resolvedExecutorSpec.executorKubernetesResources, reusablePVCs)
-      val createdExecutorPod =
-        kubernetesClient.pods().inNamespace(namespace).resource(podWithAttachedContainer).create()
+      val createdExecutorPod = kubernetesClient.pods().create(podWithAttachedContainer)
+      
+      org.apache.spark.util.LyftUtils.callObjectMethodNoArguments(
+          "com.lyft.data.spark.AppMetrics$",
+          "setFirstExecutorAllocationTime")
+      
       try {
         addOwnerReference(createdExecutorPod, resources)
         resources

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/ExecutorPodsAllocator.scala
@@ -466,12 +466,13 @@ class ExecutorPodsAllocator(
         .build()
       val resources = replacePVCsIfNeeded(
         podWithAttachedContainer, resolvedExecutorSpec.executorKubernetesResources, reusablePVCs)
-      val createdExecutorPod = kubernetesClient.pods().create(podWithAttachedContainer)
-      
+      val createdExecutorPod =
+        kubernetesClient.pods().inNamespace(namespace).resource(podWithAttachedContainer).create()
+
       org.apache.spark.util.LyftUtils.callObjectMethodNoArguments(
           "com.lyft.data.spark.AppMetrics$",
           "setFirstExecutorAllocationTime")
-      
+
       try {
         addOwnerReference(createdExecutorPod, resources)
         resources

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -532,7 +532,12 @@ private[spark] class Client(
           val localPath = getQualifiedLocalPath(localURI, hadoopConf)
           val linkname = targetDir.map(_ + "/").getOrElse("") +
             destName.orElse(Option(localURI.getFragment())).getOrElse(localPath.getName())
-          val destPath = copyFileToRemote(destDir, localPath, replication, symlinkCache)
+            var destPath = localPath
+          if (!localPath.toUri.getScheme.startsWith("s3")) {
+            destPath = copyFileToRemote(destDir, localPath, replication, symlinkCache)
+          } else {
+            logInfo(s"Adding binary from location: $destPath to the distributed cache")
+          }
           val destFs = FileSystem.get(destPath.toUri(), hadoopConf)
           distCacheMgr.addResource(
             destFs, hadoopConf, destPath, localResources, resType, linkname, statCache,
@@ -709,7 +714,7 @@ private[spark] class Client(
     pySparkArchives.foreach { f =>
       val uri = Utils.resolveURI(f)
       if (uri.getScheme != Utils.LOCAL_SCHEME) {
-        distribute(f)
+        distribute(f, LocalResourceType.ARCHIVE)
       }
     }
 


### PR DESCRIPTION
Port relevant [custom patches](https://github.com/apache/spark/compare/v3.3.1...lyft:spark:v3.3-lyft) from lyft/spark v3.3 to v.3.5.

Notably, the following commits are skipped:

- [Backport [SPARK-30707][SQL]Window function set partitionSpec as order spec when orderSpec is empty](https://github.com/apache/spark/commit/005ce7d8b0d19259e94088551a0aa8d5bf7d03d9)
    - More details in the [OSS PR](https://github.com/apache/spark/pull/27861) -- this was added at Lyft to ease transition from HiveQL -> Spark, but can be removed
- [Spark Thrift Server Fixes by rmenon](https://github.com/apache/spark/commit/719c80f020194dd4d55cedf38cebb0fe89fea301)
    - Spark Thrift Server (STS) is no longer used, it was removed from cdpclusterprovisioning in [#2003](https://github.com/lyft/cdpclusterprovisioning/pull/2003) and [#2744](https://github.com/lyft/cdpclusterprovisioning/pull/2744)
- [Trunc function does not contain the Q string (for quarter)](https://github.com/lyft/spark/commit/949dfa083c87e8b94e4b80b6af712dd428376913)
    - introduced for [Hive migration](https://confluence.lyft.net/spaces/DATA/pages/271691787/Hive+vs+Spark+and+Presto+differences), no longer needed
- [Fix Long type in theschema and int32 parquet type](https://github.com/lyft/spark/commit/73f742dd5c44eb175b67d6ccb16cb9e469ffb48e)
    - this was brought in by Lyft as a temporary fix in [this PR](https://github.com/lyft/spark/pull/43) -- since then, it seems open source updates may have provided a long-term fix [here](https://github.com/apache/spark/pull/32777/files#diff-e067188f85ea958fe1fdfc6f83466def9ca962ebd39ca9a86aaee1ed3110c045R75-R79)
- [Remove unnecessary logging statements](https://github.com/lyft/spark/commit/fe62b94a5cdcda726edb7561b9edb1f2c2689fc1)
    - non-functional logging change -- removing for simplicity & to reduce our custom patch footprint
- [Revert [SPARK-39865][SQL][3.3] Show proper error messages on the overflow commit](https://github.com/lyft/spark/commit/c93bba8b9d4823c0d891561e041eaec91be0c11b)
    - removing for simplicity & to reduce our custom patch footprint
- [Prevent YARN filter from being added to the Spark UI](https://github.com/apache/spark/commit/bc57a6de60b7b8acdf7970ac3617d529ea952a78)
    - was already reverted from our production [`spark-private` distribution](https://github.com/lyft/spark/tree/c93bba8b9d4823c0d891561e041eaec91be0c11b), no longer needed

Details are in [this doc](https://docs.google.com/document/d/1Q0mIrUBkKSQklT59M9r25ktOPTNMEGihjjhweoyq9P4/edit?tab=t.77l0kbp0eju#heading=h.tn0ikv47gqc)